### PR TITLE
Enhance API configuration for HTTPS access and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ RABBITMQ_USER=guest
 RABBITMQ_PASSWORD=changez-moi-mot-de-passe
 
 
+# API : accessible en HTTPS sur le port 443 (https://api... ou https://app.../api). Ne pas exposer le port 4000 en prod.
 API_VIRTUAL_HOST=api.rally-logistique.cloud
 API_VIRTUAL_PORT=4000
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ docker compose down
 - **app + /api** : le domaine `app.rally-logistique.cloud` sert le frontend sur `/` et proxifie `/api` vers le backend (config dans `nginx/vhost.d/`). Le frontend utilise `baseURL: "/api"`, donc les appels API passent par le même domaine.  
   Si vous changez `APP_VIRTUAL_HOST`, renommez le fichier dans `nginx/vhost.d/` en `<votre_domaine>_location_override`.
 
+### Consommer l’API en HTTPS depuis le frontend
+
+L’API n’est **pas** exposée sur un port HTTPS dédié (443 est utilisé par nginx-proxy pour tous les domaines). Elle est accessible en HTTPS de deux façons :
+
+1. **Même origine (recommandé)** : depuis l’app à `https://app.rally-logistique.cloud`, le frontend appelle `baseURL: "/api"`. Les requêtes partent en **HTTPS** vers `https://app.rally-logistique.cloud/api`, puis nginx-proxy transmet en HTTP au backend. Aucune configuration supplémentaire côté frontend.
+2. **Sous-domaine API** : `https://api.rally-logistique.cloud` (port 443). Utile pour des clients externes ou des appels directs.
+
+Le backend ne doit **pas** être exposé sur le port 4000 de l’hôte pour la prod ; l’accès se fait uniquement via le proxy (80/443). Les fichiers dans `nginx/vhost.d/*_location_override` (app et api) assurent le proxy et les en-têtes `X-Forwarded-Proto`.
+
 ## Ajouter un service en HTTPS
 
 Sur chaque conteneur à exposer en HTTPS :
@@ -78,7 +87,7 @@ Enregistrements **A** (ou **AAAA**) vers l’IP du serveur pour :
 
 - `rally-logistique.cloud`, `www.rally-logistique.cloud`
 - `app.rally-logistique.cloud`
-- `api.rally-logistique.cloud`
+- `api.rally-logistique.cloud` (si vous changez `API_VIRTUAL_HOST`, renommez `nginx/vhost.d/api.rally-logistique.cloud_location_override` en `<votre_domaine>_location_override`)
 - `db.rally-logistique.cloud`
 - `s3.rally-logistique.cloud`
 - `rabbitmq.rally-logistique.cloud`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     restart: unless-stopped
 
   # --- Backend API : api.rally-logistique.cloud (code dans ../logistia-backend) ---
+  # L'API est exposée en HTTPS sur le port 443 uniquement via nginx-proxy (pas sur le port 4000).
+  # URLs : https://api.rally-logistique.cloud ou https://app.rally-logistique.cloud/api
   backend:
     build:
       context: ../logistia-backend
@@ -75,8 +77,10 @@ services:
       MINIO_SECRET_KEY: "${MINIO_ROOT_PASSWORD}"
       MINIO_BUCKET_NAME: "${MINIO_BUCKET_NAME:-uploads}"
       MINIO_REGION: "${MINIO_REGION:-us-east-1}"
-    ports:
-      - "${API_VIRTUAL_PORT}:${API_VIRTUAL_PORT}"
+    # Ne pas exposer le port 4000 sur l'hôte : l'API est consommée en HTTPS (port 443) via le proxy.
+    # Décommenter la ligne ci‑dessous pour accès direct HTTP en debug (optionnel).
+    # ports:
+    #   - "${API_VIRTUAL_PORT:-4000}:4000"
     depends_on:
       logistique-db:
         condition: service_healthy

--- a/nginx/vhost.d/api.rally-logistique.cloud_location_override
+++ b/nginx/vhost.d/api.rally-logistique.cloud_location_override
@@ -1,0 +1,12 @@
+# API exposée en HTTPS sur le port 443 via nginx-proxy (pas sur le port 4000).
+# Ce fichier remplace le bloc location par défaut pour api.rally-logistique.cloud.
+location / {
+    proxy_pass http://backend:4000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 60s;
+    proxy_send_timeout 60s;
+}


### PR DESCRIPTION
- Updated .env.example to clarify API access via HTTPS on port 443, avoiding exposure of port 4000 in production.
- Modified docker-compose.yml to include comments on API service exposure and removed direct port mapping for production.
- Expanded README.md with detailed instructions on consuming the API over HTTPS and clarified the usage of the nginx-proxy.
- Added a new Nginx location override configuration for the API to ensure proper proxying.